### PR TITLE
feat: improve tenant host resolution for multisite compatibility

### DIFF
--- a/back/src/loaders/__tests__/tenant-loader.unit.spec.ts
+++ b/back/src/loaders/__tests__/tenant-loader.unit.spec.ts
@@ -1,0 +1,187 @@
+import type { Request, Response, NextFunction } from "express"
+
+type QueryHandlerMap = Record<string, jest.Mock>
+type ManagerMap = Record<string, unknown>
+
+const queryHandlers: QueryHandlerMap = {}
+const managers: ManagerMap = {}
+
+jest.mock("typeorm", () => {
+  class MockDataSource {
+    public isInitialized = false
+    public manager: unknown
+    private readonly name: string
+
+    constructor(options: { url?: string }) {
+      const url = options?.url ?? ""
+      const segments = url.split("/")
+      this.name = segments[segments.length - 1] || url
+      this.manager = managers[this.name] ?? { db: this.name }
+    }
+
+    initialize = jest.fn().mockImplementation(async () => {
+      this.isInitialized = true
+      return this
+    })
+
+    query = jest.fn().mockImplementation((sql: string, params?: unknown[]) => {
+      const handler = queryHandlers[this.name]
+
+      if (!handler) {
+        return Promise.resolve([])
+      }
+
+      const result = handler(sql, params)
+      return result instanceof Promise ? result : Promise.resolve(result)
+    })
+  }
+
+  return {
+    DataSource: jest.fn((options: { url?: string }) => new MockDataSource(options)),
+  }
+})
+
+const loadTenantLoader = async () => {
+  const module = await import("../tenant-loader")
+  return module
+}
+
+const buildRequest = (host: string) => {
+  return {
+    headers: { host },
+    scope: { register: jest.fn() },
+  } as unknown as Request & { scope: { register: jest.Mock } }
+}
+
+describe("tenantMiddleware", () => {
+  const originalEnv = { ...process.env }
+
+  const envKeys = [
+    "DB_USER",
+    "DB_PASS",
+    "DB_HOST",
+    "DB_PORT",
+    "MAIN_DB",
+    "ROOT_DOMAIN",
+    "WP_NETWORK_HOSTS",
+  ]
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+
+    for (const key of Object.keys(queryHandlers)) {
+      delete queryHandlers[key]
+    }
+
+    for (const key of Object.keys(managers)) {
+      delete managers[key]
+    }
+
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    }
+
+    process.env.DB_USER = "postgres"
+    process.env.DB_PASS = "postgres"
+    process.env.DB_HOST = "localhost"
+    process.env.DB_PORT = "5432"
+    process.env.MAIN_DB = "db_main"
+    process.env.ROOT_DOMAIN = "example.com"
+    process.env.WP_NETWORK_HOSTS = "network"
+  })
+
+  afterAll(() => {
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    }
+  })
+
+  it("passes through for localhost", async () => {
+    const { tenantMiddleware } = await loadTenantLoader()
+    const req = buildRequest("localhost:9000")
+    const next = jest.fn()
+
+    await tenantMiddleware(req, {} as Response, next as unknown as NextFunction)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(req.scope.register).not.toHaveBeenCalled()
+  })
+
+  it("skips lookup for apex domain", async () => {
+    queryHandlers.db_main = jest.fn().mockResolvedValue([])
+
+    const { tenantMiddleware } = await loadTenantLoader()
+    const req = buildRequest("example.com")
+    const next = jest.fn()
+
+    await tenantMiddleware(req, {} as Response, next as unknown as NextFunction)
+
+    expect(queryHandlers.db_main).not.toHaveBeenCalled()
+    expect(req.scope.register).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips lookup for network admin host", async () => {
+    queryHandlers.db_main = jest.fn().mockResolvedValue([])
+
+    const { tenantMiddleware } = await loadTenantLoader()
+    const req = buildRequest("network.example.com")
+    const next = jest.fn()
+
+    await tenantMiddleware(req, {} as Response, next as unknown as NextFunction)
+
+    expect(queryHandlers.db_main).not.toHaveBeenCalled()
+    expect(req.scope.register).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it("registers tenant manager for valid subdomain", async () => {
+    const manager = { id: "tenant-manager" }
+    managers.db_tenant = manager
+
+    queryHandlers.db_main = jest.fn().mockResolvedValue([
+      { subdomain: "acme.example.com", db_name: "db_tenant" },
+    ])
+
+    const { tenantMiddleware } = await loadTenantLoader()
+    const req = buildRequest("acme.example.com")
+    const next = jest.fn()
+
+    await tenantMiddleware(req, {} as Response, next as unknown as NextFunction)
+
+    expect(queryHandlers.db_main).toHaveBeenCalledTimes(1)
+    expect(req.scope.register).toHaveBeenCalledWith({ manager })
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it("caches failed lookups to allow passthrough", async () => {
+    const handler = jest.fn().mockResolvedValue([])
+    queryHandlers.db_main = handler
+
+    const { tenantMiddleware } = await loadTenantLoader()
+    const host = "unknown.example.com"
+
+    const firstReq = buildRequest(host)
+    const secondReq = buildRequest(host)
+    const firstNext = jest.fn()
+    const secondNext = jest.fn()
+
+    await tenantMiddleware(firstReq, {} as Response, firstNext as unknown as NextFunction)
+    await tenantMiddleware(secondReq, {} as Response, secondNext as unknown as NextFunction)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(firstReq.scope.register).not.toHaveBeenCalled()
+    expect(secondReq.scope.register).not.toHaveBeenCalled()
+    expect(firstNext).toHaveBeenCalledTimes(1)
+    expect(secondNext).toHaveBeenCalledTimes(1)
+  })
+})

--- a/back/src/loaders/tenant-loader.ts
+++ b/back/src/loaders/tenant-loader.ts
@@ -2,7 +2,129 @@ import { DataSource } from "typeorm"
 import { Request, Response, NextFunction } from "express"
 import { MedusaError } from "medusa-core-utils"
 
+type TenantRecord = {
+  db_name: string
+  subdomain: string
+}
+
 const connections: Record<string, DataSource> = {}
+const tenantMetadataCache = new Map<string, TenantRecord | null>()
+
+const DEFAULT_NETWORK_PREFIXES = ["network", "wordpress", "wp-admin", "wpadmin"]
+
+const loopbackHosts = new Set(["localhost", "127.0.0.1", "[::1]", "::1"])
+
+const parseList = (value?: string | null) =>
+  (value ? value.split(",") : [])
+    .map((prefix) => prefix.trim().toLowerCase())
+    .filter((prefix) => prefix.length > 0)
+
+const reservedPrefixes = new Set<string>([
+  "www",
+  ...DEFAULT_NETWORK_PREFIXES,
+  ...parseList(process.env.WP_NETWORK_HOSTS),
+  ...parseList(process.env.NON_TENANT_PREFIXES),
+])
+
+const normalizeHost = (rawHost?: string | null) => {
+  if (!rawHost) {
+    return ""
+  }
+
+  const trimmed = rawHost.trim().toLowerCase()
+  if (!trimmed) {
+    return ""
+  }
+
+  if (trimmed.startsWith("[") && trimmed.includes("]")) {
+    return trimmed.slice(0, trimmed.indexOf("]") + 1)
+  }
+
+  const portSeparatorIndex = trimmed.indexOf(":")
+  if (portSeparatorIndex === -1) {
+    return trimmed
+  }
+
+  return trimmed.slice(0, portSeparatorIndex)
+}
+
+const extractSubdomain = (host: string, rootDomain?: string) => {
+  if (!host || loopbackHosts.has(host)) {
+    return null
+  }
+
+  const normalizedRoot = rootDomain?.toLowerCase().trim()
+
+  if (normalizedRoot && host === normalizedRoot) {
+    return null
+  }
+
+  const normalizedHost = host.endsWith(".") ? host.slice(0, -1) : host
+
+  if (normalizedRoot && normalizedHost.endsWith(`.${normalizedRoot}`)) {
+    const hostParts = normalizedHost.split(".")
+    const rootParts = normalizedRoot.split(".")
+
+    if (hostParts.length <= rootParts.length) {
+      return null
+    }
+
+    const subParts = hostParts.slice(0, hostParts.length - rootParts.length)
+    const [firstLabel] = subParts
+
+    if (!firstLabel || reservedPrefixes.has(firstLabel)) {
+      return null
+    }
+
+    return subParts.join(".")
+  }
+
+  const hostParts = normalizedHost.split(".")
+
+  if (hostParts.length <= 1) {
+    return null
+  }
+
+  const [firstLabel] = hostParts
+
+  if (reservedPrefixes.has(firstLabel)) {
+    return null
+  }
+
+  if (normalizedRoot && hostParts.slice(1).join(".") !== normalizedRoot) {
+    return null
+  }
+
+  return firstLabel
+}
+
+const buildLookupKey = (subdomain: string, rootDomain?: string) =>
+  rootDomain ? `${subdomain}.${rootDomain}` : subdomain
+
+async function getTenantMetadata(lookupKey: string) {
+  if (tenantMetadataCache.has(lookupKey)) {
+    return tenantMetadataCache.get(lookupKey) ?? null
+  }
+
+  const mainDbName = process.env.MAIN_DB
+
+  if (!mainDbName) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "MAIN_DB environment variable must be configured for tenant resolution"
+    )
+  }
+
+  const mainDb = await getTenantConnection(mainDbName)
+  const result = await mainDb.query(`SELECT * FROM tenant WHERE subdomain=$1 LIMIT 1`, [
+    lookupKey,
+  ])
+
+  const tenant = (result?.[0] as TenantRecord | undefined) ?? null
+  tenantMetadataCache.set(lookupKey, tenant)
+
+  return tenant
+}
 
 export async function getTenantConnection(dbName: string) {
   if (connections[dbName] && connections[dbName].isInitialized) {
@@ -25,30 +147,41 @@ export async function getTenantConnection(dbName: string) {
 }
 
 export async function tenantMiddleware(req: Request, res: Response, next: NextFunction) {
-  const host = req.headers.host || ""
-  const subdomain = host.split(".")[0]
+  const normalizedHost = normalizeHost(req.headers.host)
+  const rootDomain = process.env.ROOT_DOMAIN?.toLowerCase().trim()
+  const subdomain = extractSubdomain(normalizedHost, rootDomain)
 
-  if (!subdomain || subdomain === "www") {
+  if (!subdomain) {
     return next()
   }
 
-  // Fetch tenant from MAIN_DB
-  const mainDb = await getTenantConnection(process.env.MAIN_DB as string)
-  const tenant = await mainDb.query(`SELECT * FROM tenant WHERE subdomain=$1 LIMIT 1`, [
-    `${subdomain}.${process.env.ROOT_DOMAIN}`,
-  ])
+  const lookupKey = buildLookupKey(subdomain, rootDomain)
 
-  if (!tenant.length) {
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Tenant not found for subdomain: ${subdomain}`)
+  let tenant: TenantRecord | null
+
+  try {
+    tenant = await getTenantMetadata(lookupKey)
+  } catch (error) {
+    if (error instanceof MedusaError) {
+      return next(error)
+    }
+
+    return next()
   }
 
-  const dbName = tenant[0].db_name
-  const tenantConn = await getTenantConnection(dbName)
+  if (!tenant) {
+    return next()
+  }
 
-  // Attach tenant connection to request scope
-  req.scope.register({
-    manager: tenantConn.manager,
-  })
+  try {
+    const tenantConn = await getTenantConnection(tenant.db_name)
 
-  next()
+    req.scope.register({
+      manager: tenantConn.manager,
+    })
+  } catch (error) {
+    return next(error as Error)
+  }
+
+  return next()
 }


### PR DESCRIPTION
## Summary
- normalize host handling in the tenant middleware, skip reserved multisite prefixes, and cache tenant metadata for graceful fallbacks
- add unit coverage for localhost, apex domain, network admin, unknown, and valid tenant subdomains

## Testing
- yarn --cwd back test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d5aa86882083318a5f8fcbff298971