### PR TITLE
feat(tenant): run Medusa migrations for tenants

### DIFF
--- a/back/src/modules/tenant/index.ts
+++ b/back/src/modules/tenant/index.ts
@@ -2,6 +2,7 @@ import { asClass, asValue } from "awilix"
 import TenantService, {
   TenantCreateInput,
   TenantDeleteInput,
+  TenantServiceMigrationOptions,
   TenantServiceOptions,
 } from "./tenant-service"
 import TenantSignupService from "./tenant-signup-service"
@@ -21,6 +22,11 @@ const register = (
 }
 
 export { TenantService, TenantSignupService, Tenant }
-export type { TenantCreateInput, TenantDeleteInput, TenantServiceOptions }
+export type {
+  TenantCreateInput,
+  TenantDeleteInput,
+  TenantServiceMigrationOptions,
+  TenantServiceOptions,
+}
 
 export default register

--- a/back/src/modules/tenant/tenant-migration-runner.ts
+++ b/back/src/modules/tenant/tenant-migration-runner.ts
@@ -1,0 +1,73 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+type MigrateModule = typeof import("@medusajs/medusa/commands/db/migrate")
+type LoadersModule = typeof import("@medusajs/medusa/loaders/index")
+
+let dependenciesPromise: Promise<{
+  migrate: MigrateModule["migrate"]
+  initializeContainer: LoadersModule["initializeContainer"]
+}> | null = null
+
+const loadDependencies = async () => {
+  if (!dependenciesPromise) {
+    dependenciesPromise = Promise.all([
+      import("@medusajs/medusa/commands/db/migrate"),
+      import("@medusajs/medusa/loaders/index"),
+    ]).then(([migrateModule, loadersModule]) => ({
+      migrate: migrateModule.migrate,
+      initializeContainer: loadersModule.initializeContainer,
+    }))
+  }
+
+  return dependenciesPromise
+}
+
+export type TenantMigrationContext = {
+  databaseUrl: string
+  directory: string
+  medusaProjectDir?: string
+}
+
+export type TenantMigrationRunner = (
+  context: TenantMigrationContext
+) => Promise<void>
+
+export const runTenantMigrations: TenantMigrationRunner = async (
+  context
+) => {
+  const previousDatabaseUrl = process.env.DATABASE_URL
+  const previousProjectDir = process.env.MEDUSA_PROJECT_DIR
+  const projectDir = context.medusaProjectDir ?? context.directory
+
+  process.env.DATABASE_URL = context.databaseUrl
+  process.env.MEDUSA_PROJECT_DIR = projectDir
+
+  try {
+    const { migrate, initializeContainer } = await loadDependencies()
+    const container = await initializeContainer(context.directory)
+    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+    await migrate({
+      directory: context.directory,
+      skipLinks: false,
+      skipScripts: false,
+      executeAllLinks: false,
+      executeSafeLinks: true,
+      container,
+      logger,
+    })
+
+    logger.info("✅ Tenant migrations completed")
+  } finally {
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl
+    }
+
+    if (previousProjectDir === undefined) {
+      delete process.env.MEDUSA_PROJECT_DIR
+    } else {
+      process.env.MEDUSA_PROJECT_DIR = previousProjectDir
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- invoke the Medusa migration workflow when provisioning tenant databases and surface schema validation
- expose configurable migration runner options for stubbing in tests
- update unit coverage to assert migrations are triggered and schema validation is enforced

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68d5bb08b2048331ae678b2aaeb1934a