### PR TITLE
feat: add region helper and middleware tests

### DIFF
--- a/front/src/lib/regions.ts
+++ b/front/src/lib/regions.ts
@@ -1,0 +1,200 @@
+import type { NextRequest } from "next/server"
+import { listRegions } from "@lib/data/regions"
+import type { HttpTypes } from "@medusajs/types"
+
+export type RegionMap = Map<string, HttpTypes.StoreRegion>
+
+const regionCache = new Map<string, RegionMap>()
+const DEFAULT_CACHE_KEY = "__default__"
+
+const toCacheKey = (cacheId?: string | null) => {
+  if (!cacheId) {
+    return DEFAULT_CACHE_KEY
+  }
+
+  const trimmed = cacheId.trim()
+
+  if (!trimmed) {
+    return DEFAULT_CACHE_KEY
+  }
+
+  return trimmed
+}
+
+const buildRegionMap = (regions: HttpTypes.StoreRegion[]): RegionMap => {
+  const map: RegionMap = new Map()
+
+  regions.forEach((region) => {
+    region.countries?.forEach((country) => {
+      const iso = country?.iso_2?.toLowerCase()
+
+      if (iso) {
+        map.set(iso, region)
+      }
+    })
+  })
+
+  return map
+}
+
+export const getRegionMap = async (
+  cacheId?: string | null
+): Promise<RegionMap | null> => {
+  const cacheKey = toCacheKey(cacheId)
+
+  if (regionCache.has(cacheKey)) {
+    return regionCache.get(cacheKey) ?? null
+  }
+
+  try {
+    const regions = await listRegions()
+
+    if (!regions || regions.length === 0) {
+      return null
+    }
+
+    const map = buildRegionMap(regions)
+
+    if (map.size === 0) {
+      return null
+    }
+
+    regionCache.set(cacheKey, map)
+
+    return map
+  } catch {
+    return null
+  }
+}
+
+type MinimalRequest = Pick<
+  NextRequest,
+  "headers" | "nextUrl" | "cookies"
+> & {
+  geo?: { country?: string | null } | null
+}
+
+const normalizeCountryCode = (value?: string | null) =>
+  value?.trim().toLowerCase() ?? null
+
+const getCountryFromPath = (request: MinimalRequest, regionMap: RegionMap) => {
+  const segment = request.nextUrl.pathname
+    .split("/")
+    .filter(Boolean)
+    .at(0)
+    ?.toLowerCase()
+
+  if (segment && regionMap.has(segment)) {
+    return segment
+  }
+
+  return null
+}
+
+const getCountryFromHeaders = (
+  request: MinimalRequest,
+  regionMap: RegionMap
+) => {
+  const header = request.headers.get?.("x-country-code")
+  const normalized = normalizeCountryCode(header)
+
+  if (normalized && regionMap.has(normalized)) {
+    return normalized
+  }
+
+  const acceptLanguage = request.headers.get?.("accept-language")
+
+  if (!acceptLanguage) {
+    return null
+  }
+
+  const entries = acceptLanguage
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+
+  for (const entry of entries) {
+    const [locale] = entry.split(";")
+
+    if (!locale) {
+      continue
+    }
+
+    const normalizedLocale = locale.toLowerCase()
+    const parts = normalizedLocale.split("-")
+
+    if (parts.length > 1) {
+      const regionCandidate = parts[parts.length - 1]
+
+      if (regionMap.has(regionCandidate)) {
+        return regionCandidate
+      }
+    }
+
+    if (regionMap.has(normalizedLocale)) {
+      return normalizedLocale
+    }
+  }
+
+  return null
+}
+
+const getCountryFromGeo = (
+  request: MinimalRequest,
+  regionMap: RegionMap
+) => {
+  const geoCountry = normalizeCountryCode(request.geo?.country ?? null)
+
+  if (geoCountry && regionMap.has(geoCountry)) {
+    return geoCountry
+  }
+
+  return null
+}
+
+const getFallbackCountry = (regionMap: RegionMap) => {
+  if (regionMap.has("us")) {
+    return "us"
+  }
+
+  const first = regionMap.keys().next()
+
+  if (!first.done) {
+    return first.value
+  }
+
+  return null
+}
+
+export const getCountryCode = async (
+  request: MinimalRequest,
+  regionMap: RegionMap
+): Promise<string | null> => {
+  if (!regionMap || regionMap.size === 0) {
+    return null
+  }
+
+  const fromPath = getCountryFromPath(request, regionMap)
+
+  if (fromPath) {
+    return fromPath
+  }
+
+  const fromHeaders = getCountryFromHeaders(request, regionMap)
+
+  if (fromHeaders) {
+    return fromHeaders
+  }
+
+  const fromGeo = getCountryFromGeo(request, regionMap)
+
+  if (fromGeo) {
+    return fromGeo
+  }
+
+  return getFallbackCountry(regionMap)
+}
+
+export const __clearRegionCacheForTests = () => {
+  regionCache.clear()
+}

--- a/front/src/lib/tenants/__tests__/middleware.test.ts
+++ b/front/src/lib/tenants/__tests__/middleware.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+const getRegionMapMock = vi.fn()
+const getCountryCodeMock = vi.fn()
+
+const createCookieJar = () => {
+  const store = new Map<string, { value: string; options?: Record<string, unknown> }>()
+
+  return {
+    store,
+    get: (name: string) => {
+      const entry = store.get(name)
+      return entry ? { name, value: entry.value } : undefined
+    },
+    set: (name: string, value: string, options?: Record<string, unknown>) => {
+      store.set(name, { value, options })
+    },
+  }
+}
+
+const redirectMock = vi.fn((url: string, status = 307) => ({
+  kind: "redirect" as const,
+  url,
+  status,
+  cookies: createCookieJar(),
+}))
+
+const nextMock = vi.fn(() => ({
+  kind: "next" as const,
+  cookies: createCookieJar(),
+}))
+
+vi.mock("@lib/regions", () => ({
+  getRegionMap: getRegionMapMock,
+  getCountryCode: getCountryCodeMock,
+}))
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    redirect: redirectMock,
+    next: nextMock,
+  },
+  NextRequest: class {},
+}))
+
+const { middleware } = await import("../../../middleware")
+
+const createRequest = ({
+  hostname,
+  pathname,
+  search = "",
+  cookies = {},
+}: {
+  hostname: string
+  pathname: string
+  search?: string
+  cookies?: Record<string, string>
+}): NextRequest => {
+  const url = new URL(`https://${hostname}${pathname}${search}`)
+
+  const cookieStore = new Map(
+    Object.entries(cookies).map(([name, value]) => [name, { name, value }])
+  )
+
+  return {
+    headers: new Headers(),
+    geo: {},
+    nextUrl: url,
+    cookies: {
+      get: (name: string) => cookieStore.get(name),
+    },
+  } as unknown as NextRequest
+}
+
+describe("middleware multisite redirects", () => {
+  beforeEach(() => {
+    getRegionMapMock.mockReset()
+    getCountryCodeMock.mockReset()
+    redirectMock.mockClear()
+    nextMock.mockClear()
+
+    if (!globalThis.crypto) {
+      Object.defineProperty(globalThis, "crypto", {
+        value: { randomUUID: () => "cache-id" },
+        configurable: true,
+      })
+    } else if (!("randomUUID" in globalThis.crypto)) {
+      Object.defineProperty(globalThis.crypto, "randomUUID", {
+        value: () => "cache-id",
+        configurable: true,
+      })
+    }
+  })
+
+  it("redirects tenant storefront requests to include the resolved country code", async () => {
+    const regionMap = new Map([["us", { id: "us" }]])
+    getRegionMapMock.mockResolvedValue(regionMap)
+    getCountryCodeMock.mockResolvedValue("us")
+
+    const request = createRequest({
+      hostname: "acme.example.com",
+      pathname: "/",
+    })
+
+    const response = await middleware(request)
+
+    expect(getRegionMapMock).toHaveBeenCalledOnce()
+    expect(getCountryCodeMock).toHaveBeenCalledWith(request, regionMap)
+    expect(redirectMock).toHaveBeenCalledWith("https://acme.example.com/us", 307)
+    expect(response.kind).toBe("redirect")
+  })
+
+  it("preserves primary domains while setting cache identifiers when a country segment exists", async () => {
+    const regionMap = new Map([["us", { id: "us" }]])
+    getRegionMapMock.mockResolvedValue(regionMap)
+    getCountryCodeMock.mockResolvedValue("us")
+
+    const request = createRequest({
+      hostname: "example.com",
+      pathname: "/us",
+    })
+
+    const response = await middleware(request)
+
+    expect(getRegionMapMock).toHaveBeenCalledOnce()
+    expect(getCountryCodeMock).toHaveBeenCalledWith(request, regionMap)
+    expect(redirectMock).toHaveBeenCalledWith("https://example.com/us", 307)
+    expect(response.kind).toBe("redirect")
+    expect(response.cookies.get("_medusa_cache_id")).toBeDefined()
+  })
+
+  it("allows public multisite routes to bypass region redirects", async () => {
+    const request = createRequest({
+      hostname: "network.example.com",
+      pathname: "/public/register",
+    })
+
+    const response = await middleware(request)
+
+    expect(nextMock).toHaveBeenCalledOnce()
+    expect(getRegionMapMock).not.toHaveBeenCalled()
+    expect(response.kind).toBe("next")
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable region helper that caches Medusa regions and resolves request country codes
- update the middleware to use the helper and gracefully skip redirects when no region data exists
- add Vitest coverage for tenant, primary, and public routes in a multisite network

## Testing
- `cd front && yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68d5c7231bc083318260791a31ad7172