### PR TITLE
fix(front): await tenant signup search params

### DIFF
--- a/front/src/app/public/tenants/signup/__tests__/signup-form.test.tsx
+++ b/front/src/app/public/tenants/signup/__tests__/signup-form.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import SignupForm from "../signup-form"
 

--- a/front/src/app/public/tenants/signup/page.tsx
+++ b/front/src/app/public/tenants/signup/page.tsx
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
 }
 
 type TenantSignupPageProps = {
-  searchParams?: SearchParams
+  searchParams?: Promise<SearchParams>
 }
 
 const TenantSignupPage = async ({ searchParams }: TenantSignupPageProps) => {
@@ -47,10 +47,12 @@ const TenantSignupPage = async ({ searchParams }: TenantSignupPageProps) => {
   const medusaUrl = tenant.storefront?.medusaUrl ?? process.env.MEDUSA_BACKEND_URL ?? null
   const actionUrl = resolveSignupAction(medusaUrl)
 
+  const params = ((await searchParams) ?? {}) as SearchParams
+
   const initialSubdomain =
-    firstParam(searchParams?.subdomain) ??
-    firstParam(searchParams?.tenant) ??
-    firstParam(searchParams?.site) ??
+    firstParam(params.subdomain) ??
+    firstParam(params.tenant) ??
+    firstParam(params.site) ??
     null
 
   return (

--- a/front/src/lib/tenants/__tests__/middleware.test.ts
+++ b/front/src/lib/tenants/__tests__/middleware.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import type { NextRequest } from "next/server"
 
 const getRegionMapMock = vi.fn()
@@ -44,7 +44,11 @@ vi.mock("next/server", () => ({
   NextRequest: class {},
 }))
 
-const { middleware } = await import("../../../middleware")
+let middleware: typeof import("../../../middleware")["middleware"]
+
+beforeAll(async () => {
+  ;({ middleware } = await import("../../../middleware"))
+})
 
 const createRequest = ({
   hostname,
@@ -103,7 +107,9 @@ describe("middleware multisite redirects", () => {
       pathname: "/",
     })
 
-    const response = await middleware(request)
+    const response = (await middleware(request)) as unknown as ReturnType<
+      typeof redirectMock
+    >
 
     expect(getRegionMapMock).toHaveBeenCalledOnce()
     expect(getCountryCodeMock).toHaveBeenCalledWith(request, regionMap)
@@ -121,7 +127,9 @@ describe("middleware multisite redirects", () => {
       pathname: "/us",
     })
 
-    const response = await middleware(request)
+    const response = (await middleware(request)) as unknown as ReturnType<
+      typeof redirectMock
+    >
 
     expect(getRegionMapMock).toHaveBeenCalledOnce()
     expect(getCountryCodeMock).toHaveBeenCalledWith(request, regionMap)
@@ -136,7 +144,9 @@ describe("middleware multisite redirects", () => {
       pathname: "/public/register",
     })
 
-    const response = await middleware(request)
+    const response = (await middleware(request)) as unknown as ReturnType<
+      typeof nextMock
+    >
 
     expect(nextMock).toHaveBeenCalledOnce()
     expect(getRegionMapMock).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- await the tenant signup search parameters promise before reading values
- import vitest globals in signup form tests to satisfy TypeScript
- load the middleware under test during setup and narrow mock response types

## Testing
- yarn tsc --noEmit
- curl -s -o /tmp/signup.html -w "%{http_code}" http://localhost:8000/public/tenants/signup


------
https://chatgpt.com/codex/tasks/task_e_68d5e47fb9288331bb9687c055755781