### PR TITLE
fix(front): omit credentials on tenant signup

### DIFF
--- a/front/src/app/public/tenants/signup/__tests__/signup-form.test.tsx
+++ b/front/src/app/public/tenants/signup/__tests__/signup-form.test.tsx
@@ -54,6 +54,7 @@ describe("SignupForm", () => {
 
     expect(url).toBe("https://api.example.com/public/tenants/signup")
     expect(options.method).toBe("POST")
+    expect(options.credentials).toBe("omit")
     expect(typeof options.body).toBe("string")
 
     const payload = JSON.parse(options.body as string)

--- a/front/src/app/public/tenants/signup/signup-form.tsx
+++ b/front/src/app/public/tenants/signup/signup-form.tsx
@@ -62,7 +62,7 @@ const SignupForm = ({ actionUrl, tenantName, initialSubdomain }: SignupFormProps
         headers: {
           "content-type": "application/json",
         },
-        credentials: "include",
+        credentials: "omit",
         body: JSON.stringify(payload),
       })
 


### PR DESCRIPTION
## Summary
- stop forcing cookie credentials on the tenant signup fetch call to allow cross-origin usage from multisite storefronts
- adjust the signup form test to expect the updated fetch options

## Testing
- yarn test src/app/public/tenants/signup/__tests__/signup-form.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d5ed98cc548331bc13b5b77403bedd